### PR TITLE
adding a successful and unsuccessful case to varextract

### DIFF
--- a/test/transform/varextract.jl
+++ b/test/transform/varextract.jl
@@ -261,13 +261,13 @@ end
     result = Cassette.overdub(ctx, h, [2,2,2])
     dump(ctx.metadata)
 
-    # This is the error condition
-    # ctx = TraceCtx(pass=ExtractPass, metadata = (Any[], Any[]))
-    # try
-    #     result = Cassette.overdub(ctx, h, [2,2,2]./10)
-    # catch DomainError
-    #     dump(ctx.metadata)
-    # end
+    This is the error condition
+    ctx = TraceCtx(pass=ExtractPass, metadata = (Any[], Any[]))
+    try
+        result = Cassette.overdub(ctx, h, [2,2,2]./10)
+    catch DomainError
+        dump(ctx.metadata)
+    end
 end
 
 # fst, snd = ctx.metadata


### PR DESCRIPTION
@gallupBenRyan this a good starting point for #81. Basically, we need to run the following code in a loop for lots of different training examples, based on the math, you can solve for when SQRT will fail analytically. Then generate training examples, some good and some bad. Right now the output of the trace is a little chaotic, and just goes to stdout. So a little refactoring is necessary to get this to work in a loop.

```
@testset "TraceExtract" begin
    g(x) = begin
        y = add(x.*x, -x)
        z = 1
        v = y .- z
        s = sum(v)
        return s
    end
    h(x) = begin
        z = g(x)
        zed = sqrt(z)
        return zed
    end

    # This is the success condition
    ctx = TraceCtx(pass=ExtractPass, metadata = (Any[], Any[]))
    result = Cassette.overdub(ctx, h, [2,2,2])
    dump(ctx.metadata)

    This is the error condition
    ctx = TraceCtx(pass=ExtractPass, metadata = (Any[], Any[]))
    try
        result = Cassette.overdub(ctx, h, [2,2,2]./10)
    catch DomainError
        dump(ctx.metadata)
    end
end
```

I think all the information we need is available in the dynamic trace and not the compiler pass. The pass I've written gives both the syntactic information stored in variable/function names and the value information stored in the dynamic values of the variables at run time. You might be able to get all the necessary information from a straight up `TraceCtx`.