### PR TITLE
examples to add

### DIFF
--- a/examples/stats/multiWayMarkovChainStationary.jl
+++ b/examples/stats/multiWayMarkovChainStationary.jl
@@ -1,0 +1,32 @@
+using LinearAlgebra, StatsBase
+
+# Transition probability matrix
+P = [0.5 0.4 0.1;
+     0.3 0.2 0.5;
+     0.5 0.3 0.2]
+
+# First way
+P^100
+piProb1 = (P^100)[1,:]
+
+# Second way
+A = vcat((P' - Matrix{Float64}(I, 3, 3))[1:2,:],ones(3)')
+b = [0 0 1]'
+piProb2 = A\b
+
+# Third way
+eigVecs = eigvecs(copy(P'))
+highestVec = eigVecs[:,findmax(abs.(eigvals(P)))[2]]
+piProb3 = Array{Float64}(highestVec)/norm(highestVec,1);
+
+# Fourth way
+numInState = zeros(3)
+state = 1
+N = 10^6
+for t in 1:N
+    numInState[state] += 1
+    global state = sample(1:3,weights(P[state,:]))
+end
+piProb4 = numInState/N
+
+[piProb1 piProb2 piProb3 piProb4]

--- a/examples/stats/secretaryEnvelopes.jl
+++ b/examples/stats/secretaryEnvelopes.jl
@@ -1,0 +1,44 @@
+using Random, PyPlot, StatsBase, Combinatorics
+Random.seed!(1)
+function bruteSetsProbabilityAllMiss(n)
+    omega = collect(permutations(1:n))
+    matchEvents = []
+
+    for i in 1:n
+        event = []
+        for p in omega
+            if p[i] == i
+                push!(event,p)
+            end
+        end
+        push!(matchEvents,event)
+    end
+
+    noMatch = setdiff(omega,union(matchEvents...))
+    return length(noMatch)/length(omega)
+end
+
+function formulaCalcAllMiss(n)
+    return sum([(-1)^k/factorial(k) for k in 0:n])
+end
+
+function mcAllMiss(n,N)
+    function envelopeStuffer()
+        envelopes = Random.shuffle!(collect(1:n))
+        return sum([envelopes[i] == i for i in 1:n]) == 0
+    end
+
+    data = [envelopeStuffer() for _ in 1:N]
+    return sum(data)/N
+end
+
+N = 10^6
+
+println("n\tBrute Force\tFormula\t\tMonte Carlo\t\tAnalytic",)
+for n in 1:8
+    bruteForce = bruteSetsProbabilityAllMiss(n)
+    fromFormula = formulaCalcAllMiss(n)
+    fromMC = mcAllMiss(n,N)
+    println(n,"\t",round(bruteForce,digits=4),"\t\t",round(fromFormula,digits=4),
+	"\t\t",round(fromMC,digits=4),"\t\t",round(1/MathConstants.e,digits=4))
+end


### PR DESCRIPTION
These are two problems from the [Stats Book](https://github.com/h-Klok/StatsWithJuliaBook) I think that would be good to add explaining the functionality of SemanticModels. We could try something really cool with a Markov matrix and replace the traditional inversion with an approximation like [here](https://pdfs.semanticscholar.org/2c55/daa41d4e920784581b71584bf264146a99e9.pdf). For the secretary problem there we could use Ron Howard's [policy eval](http://webee.technion.ac.il/shimkin/LCS11/ch4_RL1.pdf) and compare it to backward induction. We should also consider what other problems have well defined approximation algos that are used to replace brute force problems (ie 1.5 algo for tsp ect.) those would be a good use cases for us. 