### PR TITLE
Agenttypes

### DIFF
--- a/examples/agentbased.jl
+++ b/examples/agentbased.jl
@@ -8,22 +8,24 @@ module AgentModels
 
 import Base: count
 
-"""    AgentModel
+# """    AgentModel
 
-the root type for agent based models.
+# the root type for agent based models.
 
-See also: StateModel
-"""
+# See also: StateModel
+# """
+
 abstract type AgentModel end
 
-"""     StateModel
+# """     StateModel
 
-holds the components of an agent based simulation using finite state machines.
+# holds the components of an agent based simulation using finite state machines.
 
-- states: a collection of distinct states an agent can occupy
-- agents: a collection of states `aᵢ = agents[i] ∈ states` indicating that agent `i` is in state `aᵢ`
-- transitions: the functions `f: states -> states`
-"""
+# - states: a collection of distinct states an agent can occupy
+# - agents: a collection of states `aᵢ = agents[i] ∈ states` indicating that agent `i` is in state `aᵢ`
+# - transitions: the functions `f: states -> states`
+# """
+
 mutable struct StateModel <: AgentModel
     states
     agents
@@ -57,13 +59,13 @@ function tick!(sm::StateModel)
     sm.loads = map(s->stateload(sm, s), sm.states)
 end
 
-#     step!(sm::StateModel, n=1)
+#     step!(sm::StateModel, n)
 #
 # advance the simulation by `n` ticks of time.
 # This is an in-place operation that modifies the current state of the simulation.
 #
 
-function step!(sm::StateModel, n=1)
+function step!(sm::StateModel, n)
     for s in 1:n
       tick!(sm)
       for (i, a) in enumerate(sm.agents)
@@ -74,10 +76,11 @@ function step!(sm::StateModel, n=1)
     return sm
 end
 
-"""    describe(sm::StateModel)
+# """    describe(sm::StateModel)
 
-summarize the state of the simulation for presentation or analysis.
-"""
+# summarize the state of the simulation for presentation or analysis.
+# """
+
 function describe(sm::StateModel)
     counts = zeros(Int, size(sm.states))
     d = Dict{eltype(sm.states), Int}()

--- a/examples/agentbased.jl
+++ b/examples/agentbased.jl
@@ -57,6 +57,7 @@ end
 
 function tick!(sm::StateModel)
     sm.loads = map(s->stateload(sm, s), sm.states)
+    return sm.loads
 end
 
 #     step!(sm::StateModel, n)

--- a/examples/agentbased2.jl
+++ b/examples/agentbased2.jl
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+# ## Agent Based Modeling
+# This script is a self contained agent based model, we define a modeling microframework and then use it to implement an agent based model. This agent based model represents the SIR model of infectious disease with discrete time. This model is not intended as a realistic model of disease, but as an example of how to reverse engineer a model structure from code that implements it. See the agentgraft.jl script for an example of model augmentation on this class of models.
+#
+# Agent based models are useful for representing computations that cannot be done in closed form and need to be simulated. These simulations arise when analyzing complex systems, such as road networks, social behavior, or very small scale physical systems. The basic principles of ABM are to have agents that can be in states, and transitions between those states, the model then advances the simulation forward in time to get from an initial condition to a final condition. This framework is based on synchronous ABM where there is a global clock and all agents update their state once per clock tick.
+
+module AgentModels
+
+import Base: count
+
+# """    AgentModel
+
+# the root type for agent based models.
+
+# See also: StateModel
+# """
+
+abstract type AgentModel end
+
+# """     StateModel
+
+# holds the components of an agent based simulation using finite state machines.
+
+# - states: a collection of distinct states an agent can occupy
+# - agents: a collection of states `aᵢ = agents[i] ∈ states` indicating that agent `i` is in state `aᵢ`
+# - transitions: the functions `f: states -> states`
+# """
+
+mutable struct StateModel <: AgentModel
+    states
+    agents
+    transitions
+    loads
+end
+
+# +
+# Determine number of agents in a given state
+function count(sm::StateModel, state)
+    return length(filter(a->(a==state), sm.agents))
+end
+
+# counts the number of agents
+function count(sm::StateModel)
+    return length(sm.agents)
+end
+# -
+
+# stateload computes the fraction of agents in each state
+# it is used by tick! to update the statemodel for computing the probability of infection.
+function stateload(sm::StateModel, state::Symbol)
+    return (count(sm, state)+1)/(count(sm)+1)
+end
+
+#     tick!(sm::StateModel)
+#
+# performs the operations that need to happen once per time step. Things like caching values that need to be computed at the beginning of the timestep like the distribution of the agents' states.
+
+function tick!(sm::StateModel)
+    sm.loads = map(s->stateload(sm, s), sm.states)
+    return sm.loads
+end
+
+#     step!(sm::StateModel, n)
+#
+# advance the simulation by `n` ticks of time.
+# This is an in-place operation that modifies the current state of the simulation.
+#
+
+function step!(sm::StateModel, n)
+    for s in 1:n
+      tick!(sm)
+      for (i, a) in enumerate(sm.agents)
+          sm.agents[i] = sm.transitions(sm, i, a)
+      end
+        describe(sm)
+    end
+    return sm
+end
+
+# """    describe(sm::StateModel)
+
+# summarize the state of the simulation for presentation or analysis.
+# """
+
+function describe(sm::StateModel)
+    counts = zeros(Int, size(sm.states))
+    d = Dict{eltype(sm.states), Int}()
+    for (i,s) in enumerate(sm.states)
+        d[s] = i
+    end
+    for a in sm.agents
+        i = d[a]
+        counts[i] += 1
+    end
+    return collect(map(x->Pair(x...), zip(sm.states, counts)))
+end
+
+
+
+# ## Run the model
+#
+# This script defines a basic agent based model of disease spread called SIRS. Each agent is in one of 3 states
+#
+# 1. $S$ Susceptible
+# 2. $I$ Infected
+# 3. $R$ Recovered
+#
+# <img src="https://docs.google.com/drawings/d/e/2PACX-1vSeA7mAQ-795lLVxCWXzbkFQaFOHMpwtB121psFV_2cSUyXPyKMtvDjssia82JvQRXS08p6FAMr1hj1/pub?w=1031&amp;h=309">
+#
+# The agents go from `S->I`, `I-R`, and `R->S` based on random numbers. The probability of S-> is dependent on the fraction of agents in state :I. The probability of recovering is a constant ρ, and the disease confers some temporary immunity with probability μ.
+#
+# This script has an entrypoint to call it so that you can include this file and run as many simulations as you want. The intended use case is to repeatedly call `main` and accumulate the return values into an array for later analysis.
+
+function transition(sm::StateModel, i::Int, s::Symbol)
+    r = rand(Float64)
+    if s == :S
+        if r < stateload(sm, :I)
+            return :I
+        else
+            return :S
+        end
+    elseif s == :I
+        if r < ρ
+            return :I
+        else
+            return :R
+        end
+    elseif s == :R
+        if r < μ
+            return :R
+        else
+            return :S
+        end
+    end
+    return s
+end
+
+
+
+function main(nsteps)
+    n = 20
+    a = fill(:S, n)
+    ρ = 0.5 + randn(Float64)/4 # chance of recovery
+    μ = 0.5 # chance of immunity
+    T = transition
+
+
+    sam = StateModel([:S, :I, :R], a, T, zeros(Float64,3))
+    newsam = step!(deepcopy(sam), nsteps)
+    @show newsam.agents
+    counts = describe(newsam)
+    return newsam, counts
+end
+
+# +
+# # An example of how to run this thing.
+# main(10)
+# -
+
+end

--- a/examples/agenttypes.jl
+++ b/examples/agenttypes.jl
@@ -116,11 +116,13 @@ end
 # This script has an entrypoint to call it so that you can include this file and run as many simulations as you want. The intended use case is to repeatedly call `main` and accumulate the return values into an array for later analysis.
 
 
-ρ = 0.5 + randn(Float64)/4 # chance of recovery
+ρ = 0.5 + randn(Float64)/16 # chance of recovery
 μ = 0.5 # chance of immunity
+β = 2
 
 function transition(sm::StateModel, i::Int, s::Susceptible, args...)
-    if rand(Float64) < stateload(sm, Infected)
+    p = β*sm.loads[2]
+    if rand(Float64) < p
         return Infected()
     else
         return Susceptible()
@@ -129,9 +131,9 @@ end
 
 function transition(sm::StateModel, i::Int, s::Infected, args...)
     if rand(Float64) < ρ
-        return Infected()
-    else
         return Recovered()
+    else
+        return Infected()
     end
 end
 

--- a/examples/agenttypes.jl
+++ b/examples/agenttypes.jl
@@ -9,12 +9,13 @@ module AgentModels
 import Base: count
 
 # +
-"""    AgentModel
+# """    AgentModel
 
-the root type for agent based models.
+# the root type for agent based models.
 
-See also: StateModel
-"""
+# See also: StateModel
+# """
+
 abstract type AgentModel end
 
 abstract type State end
@@ -24,14 +25,16 @@ struct Recovered <: State end
 
 # -
 
-"""     StateModel
+# """     StateModel
 
-holds the components of an agent based simulation using finite state machines.
+# holds the components of an agent based simulation using finite state machines.
 
-- states: a collection of distinct states an agent can occupy
-- agents: a collection of states `aᵢ = agents[i] ∈ states` indicating that agent `i` is in state `aᵢ`
-- transitions: the functions `f: states -> states`
-"""
+# - states: a collection of distinct states an agent can occupy
+# - agents: a collection of states `aᵢ = agents[i] ∈ states` indicating that agent `i` is in state `aᵢ`
+# - transitions: the functions `f: states -> states`
+# """
+
+
 mutable struct StateModel{U,A,T,L} <: AgentModel
     states::U
     agents::A
@@ -65,13 +68,13 @@ function tick!(sm::StateModel)
     sm.loads = map(s->stateload(sm, s), sm.states)
 end
 
-#     step!(sm::StateModel, n=1)
+#     step!(sm::StateModel, n)
 #
 # advance the simulation by `n` ticks of time.
 # This is an in-place operation that modifies the current state of the simulation.
 #
 
-function step!(sm::StateModel, n=1)
+function step!(sm::StateModel, n)
     for s in 1:n
       tick!(sm)
       for (i, a) in enumerate(sm.agents)
@@ -82,10 +85,11 @@ function step!(sm::StateModel, n=1)
     return sm
 end
 
-"""    describe(sm::StateModel)
+# """    describe(sm::StateModel)
 
-summarize the state of the simulation for presentation or analysis.
-"""
+# summarize the state of the simulation for presentation or analysis.
+# """
+
 function describe(sm::StateModel)
     counts = zeros(Int, size(sm.states))
     d = Dict{eltype(sm.states), Int}()
@@ -120,7 +124,7 @@ end
 μ = 0.5 # chance of immunity
 β = 2
 
-function transition(sm::StateModel, i::Int, s::Susceptible, args...)
+function transition(sm::StateModel, i::Int, s::Susceptible)
     p = β*sm.loads[2]
     if rand(Float64) < p
         return Infected()
@@ -129,7 +133,7 @@ function transition(sm::StateModel, i::Int, s::Susceptible, args...)
     end
 end
 
-function transition(sm::StateModel, i::Int, s::Infected, args...)
+function transition(sm::StateModel, i::Int, s::Infected)
     if rand(Float64) < ρ
         return Recovered()
     else
@@ -137,7 +141,7 @@ function transition(sm::StateModel, i::Int, s::Infected, args...)
     end
 end
 
-function transition(sm::StateModel, i::Int, s::Recovered, args...)
+function transition(sm::StateModel, i::Int, s::Recovered)
     if rand(Float64) < μ
         return Recovered()
     else

--- a/examples/agenttypes.jl
+++ b/examples/agenttypes.jl
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+# ## Agent Based Modeling
+# This script is a self contained agent based model, we define a modeling microframework and then use it to implement an agent based model. This agent based model represents the SIR model of infectious disease with discrete time. This model is not intended as a realistic model of disease, but as an example of how to reverse engineer a model structure from code that implements it. See the agentgraft.jl script for an example of model augmentation on this class of models.
+#
+# Agent based models are useful for representing computations that cannot be done in closed form and need to be simulated. These simulations arise when analyzing complex systems, such as road networks, social behavior, or very small scale physical systems. The basic principles of ABM are to have agents that can be in states, and transitions between those states, the model then advances the simulation forward in time to get from an initial condition to a final condition. This framework is based on synchronous ABM where there is a global clock and all agents update their state once per clock tick.
+
+module AgentModels
+
+import Base: count
+
+# +
+"""    AgentModel
+
+the root type for agent based models.
+
+See also: StateModel
+"""
+abstract type AgentModel end
+
+abstract type State end
+abstract type Susceptible <: State end
+abstract type Infected <: State end
+abstract type Recovered <: State end
+
+# -
+
+"""     StateModel
+
+holds the components of an agent based simulation using finite state machines.
+
+- states: a collection of distinct states an agent can occupy
+- agents: a collection of states `aᵢ = agents[i] ∈ states` indicating that agent `i` is in state `aᵢ`
+- transitions: the functions `f: states -> states`
+"""
+mutable struct StateModel{U,A,T,L} <: AgentModel
+    states::U
+    agents::A
+    transitions::T
+    loads::L
+end
+
+# +
+# Determine number of agents in a given state
+function count(sm::StateModel, state)
+    return length(filter(a->(a==state), sm.agents))
+end
+
+# counts the number of agents
+function count(sm::StateModel)
+    return length(sm.agents)
+end
+# -
+
+# stateload computes the fraction of agents in each state
+# it is used by tick! to update the statemodel for computing the probability of infection.
+function stateload(sm::StateModel, state)
+    return (count(sm, state)+1)/(count(sm)+1)
+end
+
+#     tick!(sm::StateModel)
+#
+# performs the operations that need to happen once per time step. Things like caching values that need to be computed at the beginning of the timestep like the distribution of the agents' states.
+
+function tick!(sm::StateModel)
+    sm.loads = map(s->stateload(sm, s), sm.states)
+end
+
+#     step!(sm::StateModel, n=1)
+#
+# advance the simulation by `n` ticks of time.
+# This is an in-place operation that modifies the current state of the simulation.
+#
+
+function step!(sm::StateModel, n=1)
+    for s in 1:n
+      tick!(sm)
+      for (i, a) in enumerate(sm.agents)
+          sm.agents[i] = sm.transitions(sm, i, a)
+      end
+      @show describe(sm)
+    end
+    return sm
+end
+
+"""    describe(sm::StateModel)
+
+summarize the state of the simulation for presentation or analysis.
+"""
+function describe(sm::StateModel)
+    counts = zeros(Int, size(sm.states))
+    d = Dict{eltype(sm.states), Int}()
+    for (i,s) in enumerate(sm.states)
+        d[s] = i
+    end
+    for a in sm.agents
+        i = d[a]
+        counts[i] += 1
+    end
+    return collect(map(x->Pair(x...), zip(sm.states, counts)))
+end
+
+
+
+# ## Run the model
+#
+# This script defines a basic agent based model of disease spread called SIRS. Each agent is in one of 3 states
+#
+# 1. $S$ Susceptible
+# 2. $I$ Infected
+# 3. $R$ Recovered
+#
+# <img src="https://docs.google.com/drawings/d/e/2PACX-1vSeA7mAQ-795lLVxCWXzbkFQaFOHMpwtB121psFV_2cSUyXPyKMtvDjssia82JvQRXS08p6FAMr1hj1/pub?w=1031&amp;h=309">
+#
+# The agents go from `S->I`, `I-R`, and `R->S` based on random numbers. The probability of S-> is dependent on the fraction of agents in state :I. The probability of recovering is a constant ρ, and the disease confers some temporary immunity with probability μ.
+#
+# This script has an entrypoint to call it so that you can include this file and run as many simulations as you want. The intended use case is to repeatedly call `main` and accumulate the return values into an array for later analysis.
+
+
+ρ = 0.5 + randn(Float64)/4 # chance of recovery
+μ = 0.5 # chance of immunity
+
+function transition(sm::StateModel, i::Int, s::Type{Susceptible}, args...)
+    if rand(Float64) < stateload(sm, Infected)
+        return Infected
+    else
+        return Susceptible
+    end
+end
+
+function transition(sm::StateModel, i::Int, s::Type{Infected}, args...)
+    if rand(Float64) < ρ
+        return Infected
+    else
+        return Recovered
+    end
+end
+
+function transition(sm::StateModel, i::Int, s::Type{Recovered}, args...)
+    if rand(Float64) < μ
+        return Recovered
+    else
+        return Susceptible
+    end
+end
+
+function main(nsteps)
+    n = 20
+    @show Susceptible
+    a = Type[]
+    @show a
+    for i in 1:n
+        push!(a, Susceptible)
+    end
+    @show a
+    sam = StateModel(Any[Susceptible, Infected, Recovered], a, transition, zeros(Float64,3))
+    @show sam
+    newsam = step!(deepcopy(sam), nsteps)
+    @show newsam.agents
+    counts = describe(newsam)
+    return newsam, counts
+end
+
+# # An example of how to run this thing.
+main(10)
+
+end
+
+

--- a/examples/agenttypes.jl
+++ b/examples/agenttypes.jl
@@ -54,7 +54,7 @@ end
 # stateload computes the fraction of agents in each state
 # it is used by tick! to update the statemodel for computing the probability of infection.
 function stateload(sm::StateModel, state)
-    return (count(sm, state)+1)/(count(sm)+1)
+    return (count(sm, state))/(count(sm))
 end
 
 #     tick!(sm::StateModel)
@@ -150,9 +150,10 @@ function main(nsteps)
     @show Susceptible()
     a = Any[]
     @show a
-    for i in 1:n
+    for i in 1:n-1
         push!(a, Susceptible())
     end
+    push!(a, Infected())
     @show a
     sam = StateModel(Any[Susceptible(), Infected(), Recovered()], a, transition, zeros(Float64,3))
     @show sam

--- a/examples/agenttypes.jl
+++ b/examples/agenttypes.jl
@@ -151,18 +151,13 @@ end
 
 function main(nsteps)
     n = 20
-    @show Susceptible()
     a = Any[]
-    @show a
     for i in 1:n-1
         push!(a, Susceptible())
     end
     push!(a, Infected())
-    @show a
     sam = StateModel(Any[Susceptible(), Infected(), Recovered()], a, transition, zeros(Float64,3))
-    @show sam
     newsam = step!(deepcopy(sam), nsteps)
-    @show newsam.agents
     counts = describe(newsam)
     return newsam, counts
 end

--- a/examples/agenttypes.jl
+++ b/examples/agenttypes.jl
@@ -18,9 +18,9 @@ See also: StateModel
 abstract type AgentModel end
 
 abstract type State end
-abstract type Susceptible <: State end
-abstract type Infected <: State end
-abstract type Recovered <: State end
+struct Susceptible <: State end
+struct Infected <: State end
+struct Recovered <: State end
 
 # -
 
@@ -119,40 +119,40 @@ end
 ρ = 0.5 + randn(Float64)/4 # chance of recovery
 μ = 0.5 # chance of immunity
 
-function transition(sm::StateModel, i::Int, s::Type{Susceptible}, args...)
+function transition(sm::StateModel, i::Int, s::Susceptible, args...)
     if rand(Float64) < stateload(sm, Infected)
-        return Infected
+        return Infected()
     else
-        return Susceptible
+        return Susceptible()
     end
 end
 
-function transition(sm::StateModel, i::Int, s::Type{Infected}, args...)
+function transition(sm::StateModel, i::Int, s::Infected, args...)
     if rand(Float64) < ρ
-        return Infected
+        return Infected()
     else
-        return Recovered
+        return Recovered()
     end
 end
 
-function transition(sm::StateModel, i::Int, s::Type{Recovered}, args...)
+function transition(sm::StateModel, i::Int, s::Recovered, args...)
     if rand(Float64) < μ
-        return Recovered
+        return Recovered()
     else
-        return Susceptible
+        return Susceptible()
     end
 end
 
 function main(nsteps)
     n = 20
-    @show Susceptible
-    a = Type[]
+    @show Susceptible()
+    a = Any[]
     @show a
     for i in 1:n
-        push!(a, Susceptible)
+        push!(a, Susceptible())
     end
     @show a
-    sam = StateModel(Any[Susceptible, Infected, Recovered], a, transition, zeros(Float64,3))
+    sam = StateModel(Any[Susceptible(), Infected(), Recovered()], a, transition, zeros(Float64,3))
     @show sam
     newsam = step!(deepcopy(sam), nsteps)
     @show newsam.agents

--- a/examples/agenttypes2.jl
+++ b/examples/agenttypes2.jl
@@ -1,3 +1,7 @@
+using SemanticModels
+using SemanticModels.Parsers
+using SemanticModels.ModelTools
+
 using SemanticModels.Parsers
 import Base: ==
 
@@ -98,26 +102,19 @@ function wrap(expr::Expr)
     insert!(b, 1, :($g = Any[]))
     push!(b, :($g))
     push!(b, :(Edges($g)))
+    @show expr
     expr
 end
 
-"""    typegraph(expr::Expr)
-
-annotate a code expression so that when you eval it, you get the typegraph.
-used in the macro @typegraph.
-
-Note: Does not yet support docstrings, kwargs, or varargs.
-"""
-function typegraph(expr::Expr)
-    return wrap(postwalk, expr)
-end
-
-"""    @typegraph(expr::Expr)
-
-extract a typegraph from an expression by annotation and execution.
-
-Note: Does not yet support docstrings, kwargs, or varargs.
-"""
 macro typegraph(expr)
-    return typegraph(expr)
+    expr2 = postwalk(annotate, expr)
+    expr3 = wrap(expr2)
+    return expr3
 end
+
+expr = parsefile("agenttypes.jl")
+expr2 = wrap(postwalk(annotate, expr.args[end].args[end].args[end]))
+
+edgelist = eval(expr2)
+E = unique((f.func, f.args, f.ret) for f in edgelist)
+@show E

--- a/examples/agenttypes2.jl
+++ b/examples/agenttypes2.jl
@@ -1,120 +1,51 @@
 using SemanticModels
 using SemanticModels.Parsers
 using SemanticModels.ModelTools
+import SemanticModels.ModelTools: CallArg, RetArg, Edge, Edges, @typegraph, typegraph
 
 using SemanticModels.Parsers
 import Base: ==
 
-mutable struct Edge{S,T,R}
-    func::S
-    args::T
-    ret::R
-end
+expr = parsefile("agentbased.jl")
+expr2 = ModelTools.typegraph(expr.args[end])
+# ModEx = Expr(:Module)
+expr3 = :(module Foo 
+    using SemanticModels.ModelTools
+    import SemanticModels.ModelTools: CallArg, RetArg
+    $(expr2.args...) end)
 
-==(e::Edge,E::Edge) = begin (@show e.func==E.func && @show e.args == E.args && @show e.ret == E.ret) end
+# +
+Mod = eval(expr3)
+Mod.main(10)
+edgelist_symbol = Mod.edgelist
 
-mutable struct CallArg{S,T,U,V}
-    f::S
-    arg::T
-    T::U
-    val::V
-end
-write(io, ca::CallArg) = write(io, "$(repr(ca.f))($(repr(f.arg))::$(repr(f.T))=$(repr(f.val)))")
-
-mutable struct RetArg{S,T,U,V}
-    f::S
-    arg::T
-    T::U
-    val::V
-end
-
-
-function Edges(snapshots)
-    stack = Any[]
-    fs = Any[]
-    for snap in snapshots
-        #@show (x->x.f).(stack)
-        if !isa(snap, RetArg)
-            push!(stack, snap)
-        end
-        if isa(snap, RetArg)
-            if length(stack) <= 0
-                @show snap
-                @show fs
-                error("stack shouldn't have been empty here")
-            end
-            callargs = pop!(stack)
-            framename = first(callargs).f
-            t = Edge(framename, (x->x.T).(callargs), snap.T)
-            push!(fs, t)
-        end
-    end
-    return fs
-end
-
-head(x) = :nothing
-head(x::Expr) = x.head
-
-annotate(x::Any) = x
-
-function annotate(x::Expr)
-    # Grabing the values and types of the inputs
-    if head(x) == :function
-        b = bodyblock(x)
-        argl= argslist(x)
-        funcname = string(argl[1])
-        if length(argl) > 1
-            argl= argslist(x)[2:end]
-        else
-            argl = []
-        end
-        sargl = string.(argl)
-        v = Expr(:vect)
-        for (i, t) in enumerate(zip(sargl,argl))
-            name, val = t
-            T = :(typeof($val))
-            q = :(CallArg($funcname, $name, $T, $val))
-            push!(v.args, q)
-        end
-        insert!(b, 1, :(store($v)))
-
-    end
-    # Grabbing the return types
-    if head(x) == :return
-        g = gensym("ann")
-        s = string(x)
-        r = x.args[1]
-
-        return quote
-            $g = $r
-            T = typeof($g)
-            store(RetArg("ret", $s, T, $g))
-            return $g
-        end
-     end
-    return x
-end
-
-function wrap(expr::Expr)
-    b = expr.args
-    g = gensym("wrap_storage")
-    insert!(b, 1, :(store(args) = begin push!($g, args) end ))
-    insert!(b, 1, :($g = Any[]))
-    push!(b, :($g))
-    push!(b, :(Edges($g)))
-    @show expr
-    expr
-end
-
-macro typegraph(expr)
-    expr2 = postwalk(annotate, expr)
-    expr3 = wrap(expr2)
-    return expr3
-end
+E = unique((f.func, f.args, f.ret) for f in Edges(edgelist_symbol))
+@show E
+# -
 
 expr = parsefile("agenttypes.jl")
-expr2 = wrap(postwalk(annotate, expr.args[end].args[end].args[end]))
+expr2 = ModelTools.typegraph(expr.args[end].args[end].args[end])
+expr3 = :(module ModTyped
+    using SemanticModels.ModelTools
+    import SemanticModels.ModelTools: CallArg, RetArg
+    $(expr2.args...) end)
 
-edgelist = eval(expr2)
-E = unique((f.func, f.args, f.ret) for f in edgelist)
-@show E
+# +
+Mod = eval(expr3)
+Mod.main(10)
+edgelist_typed = Mod.edgelist
+
+E_typed = unique((f.func, f.args, f.ret) for f in Edges(edgelist_typed))
+# -
+
+println("Symbols Graph")
+for e in E
+    println(join(e, ", "))
+end
+println("\n\n=Types Graph\n\n")
+for e in E_typed
+    println(join(e, ", "))
+end
+
+
+

--- a/examples/agenttypes2.jl
+++ b/examples/agenttypes2.jl
@@ -38,14 +38,12 @@ edgelist_typed = Mod.edgelist
 E_typed = unique((f.func, f.args, f.ret) for f in Edges(edgelist_typed))
 # -
 
-println("Symbols Graph")
+println("=============\nSymbols Graph\n============")
 for e in E
     println(join(e, ", "))
 end
-println("\n\n=Types Graph\n\n")
+println("\n=============\nTypes Graph\n============")
 for e in E_typed
     println(join(e, ", "))
 end
-
-
 

--- a/examples/agenttypes2.jl
+++ b/examples/agenttypes2.jl
@@ -6,7 +6,7 @@ import SemanticModels.ModelTools: CallArg, RetArg, Edge, Edges, @typegraph, type
 using SemanticModels.Parsers
 import Base: ==
 
-expr = parsefile("agentbased.jl")
+expr = parsefile("agentbased2.jl")
 expr2 = ModelTools.typegraph(expr.args[end])
 # ModEx = Expr(:Module)
 expr3 = :(module Foo 
@@ -46,4 +46,6 @@ println("\n=============\nTypes Graph\n============")
 for e in E_typed
     println(join(e, ", "))
 end
+
+
 

--- a/src/modeltools/typegraph.jl
+++ b/src/modeltools/typegraph.jl
@@ -96,8 +96,8 @@ function wrap(expr::Expr)
     g = gensym("wrap_storage")
     insert!(b, 1, :(store(args) = begin push!($g, args) end ))
     insert!(b, 1, :($g = Any[]))
-    push!(b, :($g))
-    push!(b, :(Edges($g)))
+    push!(b, :(edgelist=$g))
+    # push!(b, :(Edges($g)))
     expr
 end
 
@@ -109,7 +109,7 @@ used in the macro @typegraph.
 Note: Does not yet support docstrings, kwargs, or varargs.
 """
 function typegraph(expr::Expr)
-    return wrap(postwalk, expr)
+    return wrap(postwalk(annotate, expr))
 end
 
 """    @typegraph(expr::Expr)

--- a/test/modeltools/typegraph.jl
+++ b/test/modeltools/typegraph.jl
@@ -10,7 +10,7 @@ end
 ex′ = postwalk(annotate, ex)
 ex2 = wrap(ex′)
 
-calls = eval(ex2)
+calls = Edges(eval(ex2))
 @test length(calls) == 2
 
 edgelist = @typegraph begin
@@ -40,4 +40,4 @@ end
 
 
 #TODO: figure out why unique(edgelist doesn't work, I think it is == of arrays of types or something.
-@test length(unique([(f.func, f.args, f.ret) for f in  edgelist])) == 5
+@test length(unique([(f.func, f.args, f.ret) for f in  Edges(edgelist)])) == 5


### PR DESCRIPTION
Add the agenttypes and agenttypes2.jl examples to show how adding more information to type system allows us to extract more information from the code. 