### PR TITLE
Make predicates succeed for any input

### DIFF
--- a/src/modeltools/exprs.jl
+++ b/src/modeltools/exprs.jl
@@ -15,31 +15,31 @@ head(n::LineNumberNode) = nothing
 
 predicate for an expression being a block node. Exists to make filter(x->head(x)==:block) shorter.
 """
-isblock(x) = head(x) == :block
+isblock(x) = isexpr(x) && head(x) == :block
 
 """    isfunc(x)
 
 predicate for an expression being a function definition. Exists to make filter(x->head(x)==:function) shorter.
 """
-isfunc(x) = head(x) == :function
+isfunc(x) = isexpr(x) && head(x) == :function
 
 """    iscall(x)
 
 predicate for an expression being a function call. Exists to make filter(x->head(x)==:call) shorter.
 """
-iscall(x) = head(x) ==:call
+iscall(x) = isexpr(x) && head(x) == :call
 
 """    isimport(x)
 
 predicate for an expression being an import statement. Exists to make filter(x->head(x)==:import) shorter.
 """
-isimport(x) = head(x) == :import
+isimport(x) = isexpr(x) && head(x) == :import
 
 """    isusing(x)
 
 predicate for an expression being a using statement. Exists to make filter(x->head(x)==:using) shorter.
 """
-isusing(x) = head(x) == :using
+isusing(x) = isexpr(x) && head(x) == :using
 
 """    or(f,g) = x->f(x) || g(x)
 """


### PR DESCRIPTION
They now simply return false when something other than an expression is used.